### PR TITLE
Update TF_Developer_NLP_Module3_Demo1_Analysing_Sentiment_With_OHE.ipynb

### DIFF
--- a/module3/TF_Developer_NLP_Module3_Demo1_Analysing_Sentiment_With_OHE.ipynb
+++ b/module3/TF_Developer_NLP_Module3_Demo1_Analysing_Sentiment_With_OHE.ipynb
@@ -65,7 +65,8 @@
     {
       "cell_type": "code",
       "source": [
-        "!pip install textblob"
+        "!pip install textblob",
+        "pip install np_utils"
       ],
       "metadata": {
         "id": "Vny3vC29NVZ8",
@@ -128,7 +129,7 @@
         "import keras.backend as K\n",
         "from keras.models import Sequential\n",
         "from keras.layers import Dense, Embedding, Lambda, Input\n",
-        "from keras.utils import np_utils\n",
+        "import np_utils\n",
         "from keras.preprocessing import sequence\n",
         "from keras.preprocessing.text import Tokenizer\n",
         "from textblob import TextBlob, Word\n",


### PR DESCRIPTION
np_utils is a separate package. Importing it from keras.utils throws a runtime error "ImportError: cannot import name 'np_utils' from 'keras.utils' (/usr/local/lib/python3.10/dist-packages/keras/utils/init.py)"

Resolved it by updating the code to first install np_utils using "pip install np_utils", then updated the import code line from "from keras.utils import np_utils" to "import np_utils"